### PR TITLE
Modify sort deadline command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListApplicationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListApplicationCommand.java
@@ -16,7 +16,7 @@ public class ListApplicationCommand extends ApplicationCommand {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all applications";
+    public static final String MESSAGE_SUCCESS = "Listed all applications in default order!";
     @Override
     public CommandResult execute(ApplicationModel model, CommandHistory commandHistory) throws CommandException {
         requireNonNull(model);

--- a/src/main/java/seedu/address/logic/commands/SortApplicationCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortApplicationCommand.java
@@ -10,6 +10,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.ApplicationModel;
 import seedu.address.model.application.AlphabeticalComparator;
 import seedu.address.model.application.Application;
+import seedu.address.model.application.ApplicationHasTaskPredicate;
 import seedu.address.model.application.DeadlineComparator;
 import seedu.address.model.application.DefaultComparator;
 
@@ -36,7 +37,10 @@ public class SortApplicationCommand extends ApplicationCommand {
     public static final String MESSAGE_CONSTRAINTS = "You can only sort alphabetically or by deadline.\n"
             + "You also need to specify the order after the command word sort.";
 
-    public static final String MESSAGE_SORT_SUCCESS = "Sorted all applications by order!";
+    public static final String MESSAGE_SORT_ALPHABETICAL_SUCCESS = "Sorted all applications by alphabetical order!";
+
+    public static final String MESSAGE_SORT_DEADLINE_SUCCESS = "Listed all applications with task deadlines"
+            + " and sorted them in order!";
 
     private final SortingOrder sortingOrder;
 
@@ -77,9 +81,15 @@ public class SortApplicationCommand extends ApplicationCommand {
     @Override
     public CommandResult execute(ApplicationModel model, CommandHistory commandHistory) throws CommandException {
         requireNonNull(model);
+        if (this.sortingOrder == SortingOrder.DEADLINE) {
+            model.updateFilteredApplicationList(new ApplicationHasTaskPredicate());
+        }
         model.updateSortedApplicationList(comparator);
         model.commitInternshipBookChange();
         commandHistory.setLastCommandAsModify();
-        return new CommandResult(MESSAGE_SORT_SUCCESS);
+        if (this.sortingOrder == SortingOrder.DEADLINE) {
+            return new CommandResult(MESSAGE_SORT_DEADLINE_SUCCESS);
+        }
+        return new CommandResult(MESSAGE_SORT_ALPHABETICAL_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/model/application/ApplicationHasTaskPredicate.java
+++ b/src/main/java/seedu/address/model/application/ApplicationHasTaskPredicate.java
@@ -1,0 +1,19 @@
+package seedu.address.model.application;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Application} has a {@code Task}
+ */
+public class ApplicationHasTaskPredicate implements Predicate<Application> {
+
+    @Override
+    public boolean test(Application application) {
+        return application.hasTask();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof ApplicationHasTaskPredicate; // instanceof handles nulls
+    }
+}


### PR DESCRIPTION
Currently the `sort deadline` command will list all applications including those without tasks (and therefore deadlines).

Let's
- modify `sort deadline` command so that it will only show applications with tasks and order them such that those with earlier deadlines are earlier
- differentiate command success result for `sort alphabetical` and `sort deadline`